### PR TITLE
make sure bucket policy depends on bucket

### DIFF
--- a/.cfnlintrc
+++ b/.cfnlintrc
@@ -1,3 +1,4 @@
 ignore_checks:
 - W1020
+- W3005
 - E1022

--- a/s3/sc-s3-encrypted-ra.yaml
+++ b/s3/sc-s3-encrypted-ra.yaml
@@ -57,6 +57,7 @@ Resources:
         'Fn::Sub': '${AWS::Region}-cfn-cr-synapse-tagger-SetBucketTagsFunctionArn'
       BucketName: !Ref S3Bucket
   S3BucketPolicy:
+    DependsOn: S3Bucket
     Type: Custom::SCS3BucketPolicy
     Properties:
       ServiceToken: !ImportValue

--- a/s3/sc-s3-synapse-ra.yaml
+++ b/s3/sc-s3-synapse-ra.yaml
@@ -69,6 +69,7 @@ Resources:
         Rules:
           - ObjectOwnership: BucketOwnerPreferred
   S3BucketPolicy:
+    DependsOn: S3Bucket
     Type: Custom::SCS3BucketPolicy
     Properties:
       ServiceToken: !ImportValue


### PR DESCRIPTION
A bucket delete may fail due to having existing data in the bucket.
When a failure occurs the bucket will remain however the  policy for it
may get removed.  This will cause a state where users will no longer
have access to the bucket.

This change makes sure that the policy deletion only happens after a
bucket has been delete.
